### PR TITLE
fix: 特殊路由框架下切换页面导致宽度为0

### DIFF
--- a/lib/components/Waterfall.vue
+++ b/lib/components/Waterfall.vue
@@ -141,7 +141,7 @@ export default defineComponent({
     watch(
       () => [wrapperWidth, colWidth, props.list],
       () => {
-        renderer()
+        if (wrapperWidth.value > 0) renderer()
       },
       { deep: true },
     )


### PR DESCRIPTION
在某些框架路由下（如Ionic），切换页面后useCalculateCols计算得出的width会变为0，导致不必要的重排
![image](https://github.com/heikaimu/vue3-waterfall-plugin/assets/20554060/16890aef-cbae-41e0-91ce-a14421589b68)

示例：

修复前
![origin-min](https://github.com/heikaimu/vue3-waterfall-plugin/assets/20554060/6850deb2-4466-4087-ba52-42246bf876e5)


修复后
![fixed-min](https://github.com/heikaimu/vue3-waterfall-plugin/assets/20554060/ae6dbe90-4f66-4b8f-907a-3aca8a8a041f)
