### PR TITLE
chore: load-props中添加ratioCalculator字段，便于手动控制瀑布流图片比例

### DIFF
--- a/lib/types/lazy.ts
+++ b/lib/types/lazy.ts
@@ -13,6 +13,7 @@ export interface LazyOptions {
   loading?: string
   observerOptions?: IntersectionObserverInit
   log?: boolean
+  ratioCalculator?: (width: number, height: number) => number
 }
 
 export interface ValueFormatterObject {

--- a/lib/utils/Lazy.ts
+++ b/lib/utils/Lazy.ts
@@ -25,6 +25,7 @@ export default class Lazy {
     error: DEFAULT_ERROR,
     observerOptions: DEFAULT_OBSERVER_OPTIONS,
     log: true,
+    ratioCalculator: (width: number, height: number) => height / width,
   }
 
   _images = new WeakMap()
@@ -35,8 +36,9 @@ export default class Lazy {
     this.config(options)
   }
 
-  config(options = {}) {
+  config(options = {} as LazyOptions) {
     assign(this.options, options)
+    options.ratioCalculator && (this.options.ratioCalculator = options.ratioCalculator)
   }
 
   // mount
@@ -101,7 +103,7 @@ export default class Lazy {
       .then((image) => {
         // 修改容器
         const { width, height } = image
-        const ratio = height / width
+        const ratio = this.options.ratioCalculator?.(width, height) || height / width
         const lazyBox = el.parentNode!.parentNode as HTMLElement
         lazyBox.style.paddingBottom = `${ratio * 100}%`
 


### PR DESCRIPTION
让用户可以控制瀑布流中图片的比例。

例如：限制图片只能为3:4或者4:3
```html
<Waterfall
    :list="dataList"
    :breakpoints="{ 1200: { rowPerView: 2 } }"
    :load-props="{
      ratioCalculator: (width: number, height: number) => {
        let ratio = 1;
        if (width > height) ratio = 3 / 4;
        else if (width < height) ratio = 4 / 3;
        return ratio;
      },
    }"
  >
    ...
</Waterfall>
```