### PR TITLE
fix：处理因浮点数经度问题，导致列数计算错误的问题

### DIFF
--- a/lib/use/useCalculateCols.ts
+++ b/lib/use/useCalculateCols.ts
@@ -34,7 +34,7 @@ export function useCalculateCols(props: WaterfallProps) {
   // 列
   const cols = computed(() => {
     const offset = props.hasAroundGutter ? -props.gutter : props.gutter
-    return Math.floor((wrapperWidth.value + offset) / (colWidth.value + props.gutter))
+    return Math.round((wrapperWidth.value + offset) / (colWidth.value + props.gutter))
   })
 
   // 偏移


### PR DESCRIPTION
因之前在项目中使用时遇到了此问题：https://github.com/heikaimu/vue3-waterfall-plugin/issues/64
一时没找到原因，自己fork源码测试了一下，顺便调整了一下。

测试过程如下：

```
// 测试配置
const options = reactive({
    rowKey: 'id',
    gutter: 10,
    hasAroundGutter: false,
    breakpoints: {
        1200: {
        rowPerView: 4,
        },
        800: {
        rowPerView: 3,
        },
        500: {
        rowPerView: 2,
        },
    },
    // 是否懒加载
    lazyload: false,
    align: 'center',
})
```

复现问题时，容器宽度为`762`，根据公式计，计算完单列宽度为 `247.33333333333334`。
然后在`useCalculateCols.ts`中计算列数的时候出现问题。

```
// 列数计算公式：
  const cols = computed(() => {
    const offset = props.hasAroundGutter ? -props.gutter : props.gutter
    return Math.round((wrapperWidth.value + offset) / (colWidth.value + props.gutter))
  })
```
我的gutter为10，`247.33333333333334 + 10 = 257.33333333333337`; 后边小数经度丢失导致值发生变化，`最后一位由4变成了7`;

预期结果为： `(762 + 10) / (257.33333333333334) = 3`
意外结果为：` (762 + 10) / (257.33333333333337) = 2.9999999999999996;`
最后再下取舍一下，变成了2列。

这地方改成`Math.round()`应该就没啥问题了，感觉没必要引入big.js或者decimal.js去处理经度问题。